### PR TITLE
Lock Faraday version to < 3.0

### DIFF
--- a/hellosign-api.gemspec
+++ b/hellosign-api.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 13.0.0'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'webmock', '>= 3.0.0'
-  spec.add_runtime_dependency 'faraday', '>= 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 2.0', '< 3.0'
   spec.add_runtime_dependency 'faraday-multipart', '>= 1.0.0'
   spec.add_runtime_dependency 'multi_json', '>= 1.0.0'
   spec.add_runtime_dependency 'mime-types', '>= 3.0.0'


### PR DESCRIPTION
### Summary

Lock Faraday version to < 3.0 to ensure future upgrades don't run into hidden issues